### PR TITLE
use p.project.eclipseAar.cleanLibsDirectoryEnabled replace extension.…

### DIFF
--- a/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/CleanTask.groovy
+++ b/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/CleanTask.groovy
@@ -14,7 +14,8 @@ class CleanTask extends BaseTask {
         findTargetProjects()
         projects.each { AndroidProject p ->
             def targets = [ p.project.file(extension.aarDependenciesDir) ]
-            if (extension.cleanLibsDirectoryEnabled) {
+            println p.project.name+".cleanLibsDirectoryEnabled="+p.project.eclipseAar.cleanLibsDirectoryEnabled
+            if (p.project.eclipseAar.cleanLibsDirectoryEnabled) {
                 targets << p.project.file('libs')
             }
             targets.each {

--- a/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/GenerateTask.groovy
+++ b/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/GenerateTask.groovy
@@ -163,7 +163,7 @@ class GenerateTask extends BaseTask {
         Set<AndroidDependency> allDependencies = []
         for (Set<AndroidDependency> d : dependencies.values()) {
             d.findAll {
-                !it.isRawJar()
+                null!=it && !it.isRawJar()
             }.each { AndroidDependency dependency ->
                 allDependencies << dependency
             }
@@ -171,29 +171,31 @@ class GenerateTask extends BaseTask {
 
         Set<AndroidDependency> latestDependencies = []
         projectDependencies.each { AndroidDependency dependency ->
-            if (dependency.isRawJar()) {
-                latestDependencies << dependency
-            } else {
-                String latestJarVersion = "0"
-                def duplicateDependencies = allDependencies.findAll {
-                    dependency.isSameArtifact(getDependencyFromFile(it.file))
-                }
-                AndroidDependency latestDependency
-                if (1 < duplicateDependencies.size()) {
-                    duplicateDependencies.each {
-                        def d = getDependencyFromFile(it.file)
-                        if (versionIsNewerThan(d?.version, latestJarVersion)) {
-                            latestJarVersion = d?.version
-                        }
-                    }
-                    latestDependency = duplicateDependencies.find { getDependencyFromFile(it.file)?.version == latestJarVersion }
+            if(null != dependency){
+                if (dependency.isRawJar()) {
+                    latestDependencies << dependency
                 } else {
-                    latestJarVersion = dependency.version
-                    latestDependency = dependency
-                }
-                if (latestDependency) {
-                    latestDependency.version = latestJarVersion
-                    latestDependencies << latestDependency
+                    String latestJarVersion = "0"
+                    def duplicateDependencies = allDependencies.findAll {
+                        dependency.isSameArtifact(getDependencyFromFile(it.file))
+                    }
+                    AndroidDependency latestDependency
+                    if (1 < duplicateDependencies.size()) {
+                        duplicateDependencies.each {
+                            def d = getDependencyFromFile(it.file)
+                            if (versionIsNewerThan(d?.version, latestJarVersion)) {
+                                latestJarVersion = d?.version
+                            }
+                        }
+                        latestDependency = duplicateDependencies.find { getDependencyFromFile(it.file)?.version == latestJarVersion }
+                    } else {
+                        latestJarVersion = dependency.version
+                        latestDependency = dependency
+                    }
+                    if (latestDependency) {
+                        latestDependency.version = latestJarVersion
+                        latestDependencies << latestDependency
+                    }
                 }
             }
         }


### PR DESCRIPTION
CleanTask 
change to 
if (p.project.eclipseAar.cleanLibsDirectoryEnabled) {
                targets << p.project.file('libs')
            }

tow project "a" and "b", in project a set cleanLibsDirectoryEnabled=false, but set cleanLibsDirectoryEnabled=true in project "b“，and b project 
dependencies{compile project(':a')}, then run gradle generateEclipseDependencies,the "libs" of project a will be delete.that was not i want.
