### PR TITLE
Add handling for artifacts with classifiers

### DIFF
--- a/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/AndroidDependency.groovy
+++ b/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/AndroidDependency.groovy
@@ -6,6 +6,7 @@ class AndroidDependency {
     String group
     String name
     String version
+    String classifier
     File file
     AndroidArtifactType artifactType
 
@@ -16,7 +17,7 @@ class AndroidDependency {
         if (isRawJar()) {
             return filenameExtStripped()
         }
-        if (!group && !name && !version) {
+        if (!group && !name && !version && !classifier) {
             return filenameExtStripped()
         }
         def list = []
@@ -28,6 +29,9 @@ class AndroidDependency {
         }
         if (version && !version.isEmpty()) {
             list << version
+        }
+        if (classifier && !classifier.isEmpty()) {
+            list << classifier
         }
         list.join(SEPARATOR)
     }
@@ -41,7 +45,7 @@ class AndroidDependency {
     }
 
     boolean isSameArtifact(AndroidDependency dependency) {
-        dependency && artifactType == dependency.artifactType && group == dependency.group && name == dependency.name
+        dependency && artifactType == dependency.artifactType && group == dependency.group && name == dependency.name && classifier == dependency.classifier
     }
 
     boolean isSameArtifactVersion(AndroidDependency dependency) {

--- a/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/GenerateTask.groovy
+++ b/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/GenerateTask.groovy
@@ -136,11 +136,12 @@ class GenerateTask extends BaseTask {
         // '-' is not always the separator of version, version itself often has '-'.
         // So we should find version from resolved dependencies.
         // Path: .../modules-2/files-2.1/group/artifact/version/hash/artifact-version.ext
+        // Path: .../modules-2/files-2.1/group/artifact/version/hash/artifact-version-classifier.ext
         def baseFilename = getBaseName(file.name)
         String target = file.path.tr(System.getProperty('file.separator'), '-')
         AndroidDependency dependency = null
         allConfigurationsDependencies.each { k, v ->
-            if ("${v.moduleName}-${v.moduleVersion}" == baseFilename) {
+            if (baseFilename ==~ /${v.moduleName}-${v.moduleVersion}.*/) {
                 // This may be the dependency of the file
                 // Find group from file path and check qualified name matches
                 if (target ==~ /.*-${v.moduleGroup}-${v.moduleName}-${v.moduleVersion}-.*/) {
@@ -150,6 +151,9 @@ class GenerateTask extends BaseTask {
                         group = v.moduleGroup
                         name = v.moduleName
                         version = v.moduleVersion
+                        if (baseFilename != "${v.moduleName}-${v.moduleVersion}") {
+                            classifier = baseFilename.replace("${v.moduleName}-${v.moduleVersion}-", '')
+                        }
                         it.file = file
                         artifactType = file.name.endsWith('jar') ? AndroidArtifactType.JAR : AndroidArtifactType.AAR
                     }

--- a/plugin/src/test/groovy/com/github/ksoichiro/eclipse/aar/AndroidDependencySpec.groovy
+++ b/plugin/src/test/groovy/com/github/ksoichiro/eclipse/aar/AndroidDependencySpec.groovy
@@ -7,60 +7,66 @@ import static com.github.ksoichiro.eclipse.aar.AndroidArtifactType.RAW_JAR
 class AndroidDependencySpec extends BaseSpec {
     def "getQualifiedName"() {
         expect:
-        result == new AndroidDependency(group: g, name: n, version: v, artifactType: a, file: f).getQualifiedName()
+        result == new AndroidDependency(group: g, name: n, version: v, classifier: c, artifactType: a, file: f).getQualifiedName()
 
         where:
-        g | n | v | a | f || result
-        'com.example.foo' | 'bar' | '1.0.0' | JAR     | new File('/path/to/file/bar-1.0.0.jar') || 'com.example.foo-bar-1.0.0'
-        null              | 'bar' | '1.0.0' | JAR     | new File('/path/to/file/bar-1.0.0.jar') || 'bar-1.0.0'
-        'com.example.foo' | null  | '1.0.0' | JAR     | new File('/path/to/file/bar-1.0.0.jar') || 'com.example.foo-1.0.0'
-        'com.example.foo' | 'bar' | null    | JAR     | new File('/path/to/file/bar-1.0.0.jar') || 'com.example.foo-bar'
-        null              | null  | null    | JAR     | new File('/path/to/file/bar-1.0.0.jar') || 'bar-1.0.0'
-        null              | null  | null    | JAR     | null                                    || ''
-        null              | null  | null    | RAW_JAR | new File('/path/to/file/bar-1.0.0.jar') || 'bar-1.0.0'
+        g | n | v | c | a | f || result
+        'com.example.foo' | 'bar' | '1.0.0' | 'staging' | JAR     | new File('/path/to/file/bar-1.0.0-staging.jar') || 'com.example.foo-bar-1.0.0-staging'
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR     | new File('/path/to/file/bar-1.0.0.jar')         || 'com.example.foo-bar-1.0.0'
+        null              | 'bar' | '1.0.0' | null      | JAR     | new File('/path/to/file/bar-1.0.0.jar')         || 'bar-1.0.0'
+        'com.example.foo' | null  | '1.0.0' | null      | JAR     | new File('/path/to/file/bar-1.0.0.jar')         || 'com.example.foo-1.0.0'
+        'com.example.foo' | 'bar' | null    | null      | JAR     | new File('/path/to/file/bar-1.0.0.jar')         || 'com.example.foo-bar'
+        null              | null  | null    | null      | JAR     | new File('/path/to/file/bar-1.0.0.jar')         || 'bar-1.0.0'
+        null              | null  | null    | null      | JAR     | null                                            || ''
+        null              | null  | null    | null      | RAW_JAR | new File('/path/to/file/bar-1.0.0.jar')         || 'bar-1.0.0'
     }
 
     def "isSameArtifact"() {
         expect:
-        result == new AndroidDependency(group: g1, name: n1, version: v1, artifactType: a1)
-                .isSameArtifact(new AndroidDependency(group: g2, name: n2, version: v2, artifactType: a2))
+        result == new AndroidDependency(group: g1, name: n1, version: v1, classifier: c1, artifactType: a1)
+                .isSameArtifact(new AndroidDependency(group: g2, name: n2, version: v2, classifier: c2, artifactType: a2))
 
         where:
-        g1                | n1    | v1      | a1   | g2                 | n2     | v2            | a2   || result
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0'         | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1'           | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.1'       | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0-alpha' | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | null          | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'blur' | '1.0.0'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'blur' | '1.0'         | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'blur' | '1'           | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'blur' | '1.0.1'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'blur' | '1.0.0-alpha' | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'baz'  | '1.0.0-alpha' | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | null   | '1.0.0'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.blur' | 'bar'  | '1.0.0'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.blur' | 'bar'  | '1.0'         | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.blur' | 'bar'  | '1'           | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.blur' | 'bar'  | '1.0.1'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.blur' | 'bar'  | '1.0.0-alpha' | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.baz'  | 'bar'  | '1.0.0'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | null               | 'bar'  | '1.0.0'       | JAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | AAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0'         | AAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1'           | AAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.1'       | AAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0-alpha' | AAR  || false
-        'com.example.foo' | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null || false
-        null              | 'bar' | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | JAR  || false
-        'com.example.foo' | null  | '1.0.0' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | JAR  || false
-        'com.example.foo' | 'bar' | null    | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | null | 'com.example.foo'  | 'bar'  | '1.0.0'       | JAR  || false
-        null              | 'bar' | '1.0.0' | JAR  | null               | 'bar'  | '1.0.0'       | JAR  || true
-        'com.example.foo' | null  | '1.0.0' | JAR  | 'com.example.foo'  | null   | '1.0.0'       | JAR  || true
-        'com.example.foo' | 'bar' | null    | JAR  | 'com.example.foo'  | 'bar'  | null          | JAR  || true
-        'com.example.foo' | 'bar' | '1.0.0' | null | 'com.example.foo'  | 'bar'  | '1.0.0'       | null || true
+        g1                | n1    | v1      | c1        | a1   | g2                 | n2     | v2            | c2        | a2   || result
+        'com.example.foo' | 'bar' | '1.0.0' | 'staging' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | 'staging' | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | 'staging' | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0-alpha' | 'staging' | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | 'staging' | AAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | 'prod'    | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | 'staging' | AAR  | 'com.example.foo'  | 'bar'  | '1.0.0-alpha' | 'prod'    | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | 'prod'    | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0'         | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1'           | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.1'       | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0-alpha' | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | null          | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'blur' | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'blur' | '1.0'         | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'blur' | '1'           | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'blur' | '1.0.1'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'blur' | '1.0.0-alpha' | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'baz'  | '1.0.0-alpha' | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | null   | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.blur' | 'bar'  | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.blur' | 'bar'  | '1.0'         | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.blur' | 'bar'  | '1'           | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.blur' | 'bar'  | '1.0.1'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.blur' | 'bar'  | '1.0.0-alpha' | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.baz'  | 'bar'  | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | null               | 'bar'  | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0'         | null      | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1'           | null      | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.1'       | null      | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0-alpha' | null      | AAR  || false
+        'com.example.foo' | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | null || false
+        null              | 'bar' | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | null  | '1.0.0' | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | JAR  || false
+        'com.example.foo' | 'bar' | null    | null      | JAR  | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | null | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | JAR  || false
+        null              | 'bar' | '1.0.0' | null      | JAR  | null               | 'bar'  | '1.0.0'       | null      | JAR  || true
+        'com.example.foo' | null  | '1.0.0' | null      | JAR  | 'com.example.foo'  | null   | '1.0.0'       | null      | JAR  || true
+        'com.example.foo' | 'bar' | null    | null      | JAR  | 'com.example.foo'  | 'bar'  | null          | null      | JAR  || true
+        'com.example.foo' | 'bar' | '1.0.0' | null      | null | 'com.example.foo'  | 'bar'  | '1.0.0'       | null      | null || true
     }
 
     def "isSameArtifact with null"() {

--- a/plugin/src/test/groovy/com/github/ksoichiro/eclipse/aar/GenerateTaskSpec.groovy
+++ b/plugin/src/test/groovy/com/github/ksoichiro/eclipse/aar/GenerateTaskSpec.groovy
@@ -21,9 +21,10 @@ class GenerateTaskSpec extends BaseSpec {
         result == GenerateTask.getBaseName(filename)
 
         where:
-        filename                || result
-        'artifact-version.ext'  || 'artifact-version'
-        'support-v4-21.0.2.aar' || 'support-v4-21.0.2'
+        filename                           || result
+        'artifact-version.ext'             || 'artifact-version'
+        'artifact-version-classifier.ext'  || 'artifact-version-classifier'
+        'support-v4-21.0.2.aar'            || 'support-v4-21.0.2'
     }
 
     def versionIsNewerThan() {
@@ -93,6 +94,54 @@ class GenerateTaskSpec extends BaseSpec {
         'android-observablescrollview' == dependency.name
         '1.5.0' == dependency.version
         dependencyFile == dependency.file
+        'android-observablescrollview-1.5.0.aar' == dependency.file.name
+    }
+
+    def "getDependencyFromFile with classifier"() {
+        setup:
+        File dependencyFile = new File(
+                "/this/path/does/not/exist/but/it/is/enough/for/this/test/"
+                        + ".gradle/caches/modules-2/files-2.1/"
+                        + "com.github.ksoichiro/android-observablescrollview/1.5.0/"
+                        + "a44e58f48b8eac8c16cd99c35ed2f69078354999/"
+                        + "android-observablescrollview-1.5.0-staging.aar")
+        def resolvedDependency = new DummyResolvedDependency(
+                moduleGroup: "com.github.ksoichiro",
+                moduleName: "android-observablescrollview",
+                moduleVersion: "1.5.0")
+
+        def resolvedDependency2 = new DummyResolvedDependency(
+                moduleGroup: "com.nineoldandroids",
+                moduleName: "library",
+                moduleVersion: "2.4.0")
+
+        def resolvedDependency3 = new DummyResolvedDependency(
+                moduleGroup: "somebody",
+                moduleName: "android-observablescrollview",
+                moduleVersion: "1.5.0")
+
+        Project project = ProjectBuilder.builder().build()
+        project.plugins.apply PLUGIN_ID
+        GenerateTask task = project.tasks.generateEclipseDependencies as GenerateTask
+        task.allConfigurationsDependencies = [:]
+        // This will be skipped
+        task.allConfigurationsDependencies['com.nineoldandroids:library:2.4.0'] = resolvedDependency2
+        // This will be also skipped
+        task.allConfigurationsDependencies['somebody:android-observablescrollview:1.5.0'] = resolvedDependency3
+        // And this will be assumed as the expected dependency
+        task.allConfigurationsDependencies['com.github.ksoichiro:android-observablescrollview:1.5.0'] = resolvedDependency
+
+        when:
+        AndroidDependency dependency = task.getDependencyFromFile(dependencyFile)
+
+        then:
+        dependency
+        AndroidArtifactType.AAR == dependency.artifactType
+        'com.github.ksoichiro' == dependency.group
+        'android-observablescrollview' == dependency.name
+        '1.5.0' == dependency.version
+        dependencyFile == dependency.file
+        'android-observablescrollview-1.5.0-staging.aar' == dependency.file.name
     }
 
     def "getDependencyFromFile not found"() {


### PR DESCRIPTION
The v0.2.0 plugin is unable to download artifacts with a Maven classifier specified with:

```
compile 'group:name:version:classifier'
```

This error is print for that artifact:

> "ERROR: Could not find dependency: ${target}"

The correct place to find the file is:
**.../modules-2/files-2.1/group/artifact/version/hash/artifact-version-classifier.ext**

This change adds support for handling these classifiers. Please let me know if this is the correct fix, and thanks for publishing this plugin.
