### PR TITLE
Force file permissions to 644 when extracting AARs

### DIFF
--- a/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/GenerateTask.groovy
+++ b/plugin/src/main/groovy/com/github/ksoichiro/eclipse/aar/GenerateTask.groovy
@@ -215,6 +215,7 @@ class GenerateTask extends BaseTask {
         boolean isAarDependency = dependency.artifactType == AndroidArtifactType.AAR
         def copyClosure = isAarDependency ? { destDir ->
             p.project.copy { CopySpec it ->
+                it.setFileMode(644)
                 it.from p.project.zipTree(dependency.file)
                 it.exclude 'classes.jar'
                 it.into dependencyProjectRootPath
@@ -238,6 +239,7 @@ class GenerateTask extends BaseTask {
         copyClosure('libs')
         if (isAarDependency) {
             p.project.copy { CopySpec it ->
+                it.setFileMode(644)
                 it.from p.project.zipTree(dependency.file)
                 it.exclude 'classes.jar'
                 it.into dependencyProjectRootPath


### PR DESCRIPTION
This addresses #17. Basically the file permission issue can be reproduced by including in your project any version of Google Play Services Client Library v9 and above, such as:

```
compile 'com.google.android.gms:play-services-basement:10.2.4'
```

I believe the real issue may be in Gradle. This workaround allows GPS AARs to be extracted, but also forces file permissions to 644.